### PR TITLE
Throw exception instead of exit when user is not found

### DIFF
--- a/src/Exceptions/UserNotFound.php
+++ b/src/Exceptions/UserNotFound.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BitsnBolts\Flysystem\Sharepoint\Exceptions;
+
+use League\Flysystem\FilesystemException;
+use RuntimeException;
+use Throwable;
+
+class UserNotFound extends RuntimeException implements FilesystemException
+{
+    public static function withLoginName(string $loginName, ?Throwable $previous = null): self
+    {
+        return new self(
+            "SharePoint user '{$loginName}' was not found in Office 365.",
+            0,
+            $previous
+        );
+    }
+}

--- a/src/SharepointAdapter.php
+++ b/src/SharepointAdapter.php
@@ -3,6 +3,7 @@
 namespace BitsnBolts\Flysystem\Sharepoint;
 
 use BitsnBolts\Flysystem\Sharepoint\Enums\AuthType;
+use BitsnBolts\Flysystem\Sharepoint\Exceptions\UserNotFound;
 use Exception;
 use League\Flysystem\Config;
 use League\Flysystem\DirectoryAttributes;
@@ -754,7 +755,7 @@ class SharepointAdapter implements FilesystemAdapter
         try {
             $user = $this->client->getWeb()->ensureUser($loginName)->executeQuery();
         } catch (Exception $e) {
-            exit('<b>Foutmelding:</b> De gebruikersnaam '.$loginName.' is niet gevonden in Office 365.');
+            throw UserNotFound::withLoginName($loginName, $e);
         }
 
         return $user;


### PR DESCRIPTION
When the user is not found, we should throw an exception instead of exiting the program. This allows the calling code to handle the error gracefully and take appropriate action, rather than abruptly terminating the program.